### PR TITLE
feat: Possibilidade de sincronia em mais de 1 diretorio

### DIFF
--- a/workstation/files/sync_git.sh
+++ b/workstation/files/sync_git.sh
@@ -17,13 +17,18 @@ then
 	echo "------------------------------"
 	echo "Não foi informado um diretório"
 	echo -e "------------------------------\n"
-	echo "MODO DE USO: ./sync_git.sh DIRETORIO"
+	echo "MODO DE USO: ./sync_git.sh CAMINHO/DIRETORIO_1 CAMINHO/DIRETORIO_2 CAMINHO/DIRETORIO_N"
 	exit 1
 fi
 
-while read diretorio;
+while [[ -n $1 ]]
 do
-	echo -e "\n\033[1;32m*** Sincronizando o repositório ${diretorio/\/.git/} ***\033[0m"
-	git -C ${diretorio/\/.git/} pull
-	
-done <<< $(find "$1" -maxdepth 3 -type d -name .git)
+	while read diretorio;
+	do
+		echo -e "\n\033[1;32m*** Sincronizando o repositório ${diretorio/\/.git/} ***\033[0m"
+		git -C "${diretorio/\/.git/}" pull
+		
+	done <<< "$(find "$1" -maxdepth 3 -type d -name .git)"
+
+	shift
+done


### PR DESCRIPTION
**### O que foi feito?**
Foi adicionado ao script a possibilidade de realizar a sincronização em mais de um diretório que contenham repositórios git.

**### Porque foi feito?**
Mostrou-se útil a possibilidade de implementar a sincronia de repositórios git que estejam organizados por tipo, por exemplo, um diretório para gitlab, outro para github e assim por diante. Com tal alteração o script passará, desde que seja informado, percorrer estes diretórios e iniciar a sincronia dos mesmos.