### PR TITLE
feat: Instalação do AWS-CLI V2 e outras correções

### DIFF
--- a/workstation/tasks/aws_package.yaml
+++ b/workstation/tasks/aws_package.yaml
@@ -1,16 +1,31 @@
-# AWS CLI via apt
-- name: Installing AWS CLI
+# AWS CLI V1 via apt
+- name: Installing AWS CLI via APT
   become: true
   apt:
     install_recommends: yes
     name: awscli
-  when: '{{ awscli_install_mode is match("apt") }}'
+  when: '{{ awscli_install_mode is match("apt") and awscli_version is match("v1") }}'
 
-# AWS CLI via pip
-- name: Installing AWS CLI
+# AWS CLI AWS CLI V1 via pip
+- name: Installing AWS CLI via PIP
   shell:
     cmd: 'python -m pip install awscli --upgrade --user'
-  when: '{{ awscli_install_mode is match("pip") }}'
+  when: '{{ awscli_install_mode is match("pip") and awscli_version is match("v1") }}'
+
+# AWS CLI V2 via repo AWS  
+- name: Downloading AWS CLI V2
+  unarchive:
+    src: 'https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip'
+    dest: '/tmp/'
+    remote_src: yes
+    creates: '/tmp/aws'
+  when: '{{ awscli_version is match("v2") }}'
+
+- name: Installing AWS CLI V2
+  become: true
+  shell:
+    cmd: '/tmp/aws/install'
+  when: '{{ awscli_version is match("v2") }}'
 
 # Adicionar alias caso seja instalado via pip
 - name: Check if bashrc exists
@@ -23,7 +38,7 @@
     path: '{{ home_user }}/.bashrc'
     line: 'alias aws="python -m awscli"'
     state: present
-  when: bashrc.stat.exists
+  when: '{{ bashrc.stat.exists and awscli_install_mode is match("pip") and awscli_version is match("v1") }}'
 
 - name: Check if zshrc exists
   stat:
@@ -35,7 +50,7 @@
     path: '{{ home_user }}/.zshrc'
     line: 'alias aws="python -m awscli"'
     state: present
-  when: zshrc.stat.exists
+  when: '{{ zshrc.stat.exists and awscli_install_mode is match("pip") and awscli_version is match("v1") }}'
 
 # AWS SSM
 - name: Installing AWS SSM
@@ -44,7 +59,7 @@
     deb: https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb
 
 # AWS IAM Authentication
-- name: Downloading IAM Authentication
+- name: Installing IAM Authentication
   become: true
   get_url:
     url: 'https://amazon-eks.s3-us-west-2.amazonaws.com/{{ iam_auth_version }}/2019-08-22/bin/linux/amd64/aws-iam-authenticator'

--- a/workstation/vars/main.yaml
+++ b/workstation/vars/main.yaml
@@ -5,6 +5,9 @@ app_path: 'export PATH="$PATH:/usr/local/go/bin:${KREW_ROOT:-$HOME/.krew}/bin:/o
 # AWS modo de instalação, opção pip ou apt
 awscli_install_mode: 'pip'
 
+# Versão do AWS CLI - opção v1 ou v2
+awscli_version: 'v1'
+
 # AWS IAM VERSION
 iam_auth_version: '1.14.6'
 
@@ -48,5 +51,8 @@ kubepug_version: 'v1.1.3'
 terraform_docs_version: 'v0.15.0'
 
 # YQ
-yq_version: 'v4.24.2'
+# Nota: As versões 4.1.0 e recentes possuem a letra v antes do número da versão
+# as versões mais antigas 4.0.0 e anteriores não possuem tal letra.
+# Verificar a nomenclatura e alterar a variável antes de iniciar o playbook
+yq_version: '3.4.1'
 yq_binary: 'yq_linux_amd64'


### PR DESCRIPTION
### O que foi feito?
Foi adicionada a possibilidade de instalação da versão 2 do AWS CLI e realizado outros ajustes nas condições para adição de alias para o programa quando instalado a versão 1 via pip e uma anotação no arquivo de variáveis, pois as versões mais antigas do yq tem urls diferentes das versões atuais.

### Porque foi feito?
Pelo fato de alguns necessitarem da versão 2 do AWS CLI, tornou-se necessário tal implementação e quanto aos ajustes de condicionais foi notado que, quando a variável permanecia com o valor pip, o ansible adicionava um alias independente se foi instalado ou não, isso ficou evidente quando fazemos a instalação da versão 2 do AWS CLI.