### PR TITLE
fix: copia do script sync_git para home

### DIFF
--- a/workstation/tasks/misc.yaml
+++ b/workstation/tasks/misc.yaml
@@ -8,7 +8,7 @@
 # Copia o script que fará 
 # as atualizações do repositório
 - name: Copy script to update git dir repo
-  file:
+  copy:
     src: '{{ role_path }}/files/sync_git.sh'
     dest: '{{ home_user }}'
     mode: '0775'


### PR DESCRIPTION
## O que foi feito?
Foi realizado um ajuste  no módulo para copiar o arquivo que realizava o sync dos repositórios git.

## Porque foi feito?
Quando o playbook era executado, ele apresentava falha na cópia do arquivo e interrompia a execução.