### PR TITLE
fix: tgenv list remote

### DIFF
--- a/workstation/files/tgenv-list-remote
+++ b/workstation/files/tgenv-list-remote
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -e
+
+[ -n "${TGENV_DEBUG}" ] && set -x
+source "${TGENV_ROOT}/libexec/helpers"
+
+if [ ${#} -ne 0 ];then
+  echo "usage: tgenv list-remote" 1>&2
+  exit 1
+fi
+
+# count
+i=1
+
+# number of pages
+page_number=2
+
+while [[ "$i" -le "$page_number" ]]
+do
+
+	if [[ "$i" -eq 1 ]]
+	then
+		link_release="https://api.github.com/repos/gruntwork-io/terragrunt/tags?per_page=1000"
+	else
+		link_release="https://api.github.com/repos/gruntwork-io/terragrunt/tags?per_page=1000&page=$i"
+	fi
+
+	print+=$(curl --tlsv1.2 -sf $link_release)
+
+	((i += 1))
+
+	# Grace period to make a new request
+	sleep 1
+
+done
+
+return_code=$?
+if [ $return_code -eq 22 ];then
+  warn_and_continue "Failed to get list verion on $link_release"
+  print=`cat ${TGENV_ROOT}/list_all_versions_offline`
+fi
+
+echo $print | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta)[0-9]+)?" | uniq

--- a/workstation/tasks/tgenv_package.yaml
+++ b/workstation/tasks/tgenv_package.yaml
@@ -22,10 +22,10 @@
 # Altera o link para aumentar o escopo da busca
 # na api do github https://github.com/cunymatthieu/tgenv/blob/master/libexec/tgenv-list-remote#L12
 - name: Fix github api link
-  lineinfile:
-    path: '{{ home_user }}/.tgenv/libexec/tgenv-list-remote'
-    regexp: '^link_release='
-    line: 'link_release="https://api.github.com/repos/gruntwork-io/terragrunt/tags?per_page=1000&page=2"'
+  copy:
+    src: '{{ role_path }}/files/tgenv-list-remote'
+    dest: '{{ home_user }}/.tgenv/libexec/tgenv-list-remote'
+    mode: '0755'
 
 # Instala as versões do terraform
 - name: Installing terragrunt versions


### PR DESCRIPTION
## O que foi feito?
Foi adicionado ao script tgenv-list-remote a possibilidade de listar mais de uma página de releases.

## Porque foi feito?
O fix sugerido originalmente não possibilitava a instalação de versões recentes do terragrunt.